### PR TITLE
Notify delegate when video is not embeddable

### DIFF
--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -582,7 +582,10 @@ NSString static *const kYTPlayerStaticProxyRegexPattern = @"^https://content.goo
           float time = [data floatValue];
           [self.delegate playerView:self didPlayTime:time];
       }
-      
+  } else if ([action isEqualToString:kYTPlayerCallbackOnYouTubeIframeAPIReady]) {
+      if ([self.delegate respondsToSelector:@selector(playerView:receivedError:)]) {
+          [self.delegate playerView:self receivedError:kYTPlayerErrorNotEmbeddable];
+      }
   }
 }
 


### PR DESCRIPTION
This patch allows the YTPlayerView delegate to respond appropriately when the video cannot be embedded, for example by opening the YouTube app. An example YouTube video ID which cannot be embedded is "QcIy9NiNbmo"
